### PR TITLE
Accommodate southern hemisphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Here's a sample run showing all off essentially all of the functionality.
     
     39.264654456410966d0
     -105.39627074290249d0
+    * (utm:utm-to-lat-lon 422700.0 7605232.0 -53) #| negative zone for southern hemisphere |#
+
+    -21.654466375054866d0
+    134.25293203530634d0
+    * (utm:lat-lon-to-utm -21.654466375054866d0 134.25293203530634d0)
+
+    422700.00003077503d0
+    7605232.0000484595d0
+    -53
     * (utm:lat-lon-to-utm 39.264657358 -105.396267073 :ellipsoid "WGS72")
     
     465814.3743203891d0

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -73,7 +73,7 @@
                        :latitude -29.3438753994d0
                        :longitude 130.8032226563d0
                        :ellipsoid "GRS80"
-                       :zone 52
+                       :zone -52
                        :easting 675064.430d0
                        :northing 6752564.671d0)))
 

--- a/utm.lisp
+++ b/utm.lisp
@@ -222,7 +222,7 @@
       ((reasting (- easting 500000.0d0))
        (northing (if (< 0 zone)
                      northing
-                     (- northing 10000000.0d0)))
+                     (- northing N0)))
        (zone (abs zone))
        (a (car (gethash ellipsoid *ellipsoids*)))
        (b (cdr (gethash ellipsoid *ellipsoids*)))

--- a/utm.lisp
+++ b/utm.lisp
@@ -89,7 +89,7 @@
          (e-prime-squared (/ e-squared
                              (- 1.0d0 e-squared)))
          (nzone (if zone
-                    zone
+                    (abs zone)
                     (ceiling (/ (+ lon 180.0d0)
                                 6.0d0))))
 
@@ -205,7 +205,9 @@
             (if (< lat 0)
                 (+ N0 northing)
                 northing)
-            nzone)))
+            (if (< lat 0)
+                (- nzone)
+                nzone))))
 
 ;; Again, see the references for an explanation of what's going on
 ;; * http://www.uwgb.edu/dutchs/UsefulData/UTMFormulas.htm
@@ -218,6 +220,10 @@
            )
   (let*
       ((reasting (- easting 500000.0d0))
+       (northing (if (< 0 zone)
+                     northing
+                     (- northing 10000000.0d0)))
+       (zone (abs zone))
        (a (car (gethash ellipsoid *ellipsoids*)))
        (b (cdr (gethash ellipsoid *ellipsoids*)))
        (f (/ (- a b)


### PR DESCRIPTION
I wanted this to work for the southern hemisphere. Another UTM project had code that suggested a solution (https://github.com/wtw-software/UTMConversion/blob/master/UTMConversion/TMCoordinate.swift) for adjusting the northing value input which fortunately worked. The utm-ups package uses negative values for the utm zone for southern hemisphere which I've adopted here. Hope this is useful